### PR TITLE
Fix parsing quoted nodes

### DIFF
--- a/OGDL/Parser.swift
+++ b/OGDL/Parser.swift
@@ -125,7 +125,7 @@ private let block: Int -> Parser<()>.Function = { n in const(nil) }
 /// Parses a single descendent element.
 ///
 /// This is an element which may be an in-line descendent, and which may further have in-line descendents of its own.
-private let descendent = (word | quoted) --> { Node(value: $0) }
+private let descendent = value --> { Node(value: $0) }
 
 /// Parses a sequence of hierarchically descending elements, e.g.:
 ///

--- a/OGDLTests/ParserSpec.swift
+++ b/OGDLTests/ParserSpec.swift
@@ -61,6 +61,19 @@ class ParserSpec: QuickSpec {
 			expect(parsedGraph).to(equal(expectedGraph))
 		}
 
+		it("should parse quoted nodes") {
+			let expectedGraph = [
+				Node(value: "foo", children: [
+					Node(value: "bar", children: [
+						Node(value: "fuzz buzz")
+					])
+				])
+			]
+
+			let parsedGraph = parse(graph, "foo \"bar\" \"fuzz buzz\"")
+			expect(parsedGraph).to(equal(expectedGraph))
+		}
+
 		// TODO: Not yet supported. See Carthage/ogdl-swift#6.
 		pending("should parse siblings") {
 			let expectedGraph = [


### PR DESCRIPTION
We would consider `'` and `"` to be characters in the string, rather than the string terminators, and so quoted string parsing would always fail (as I understand it).
